### PR TITLE
実際のブログに合わせて id="container" の div を追加し、body の id を削除

### DIFF
--- a/src/archive/category/entries.html
+++ b/src/archive/category/entries.html
@@ -28,7 +28,7 @@
     <!-- ### その他の読み込みタグ（JS・CSS等） ### -->
 </head>
 
-<body id="archive-category-entries-page">
+<body>
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
 
     <div id="container">

--- a/src/archive/category/entries.html
+++ b/src/archive/category/entries.html
@@ -31,6 +31,7 @@
 <body id="archive-category-entries-page">
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
 
+    <div id="container">
     <!-- ### ヘッダー ### -->
     <header class="main-header">
         <div class="main-header__inner">
@@ -251,5 +252,6 @@
                 href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
         </div>
     </footer>
+    </div>
 </body>
 </html>

--- a/src/archive/category/logs.html
+++ b/src/archive/category/logs.html
@@ -28,7 +28,7 @@
     <!-- ### その他の読み込みタグ（JS・CSS等） ### -->
 </head>
 
-<body id="archive-category-logs-page">
+<body>
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
 
     <div id="container">

--- a/src/archive/category/logs.html
+++ b/src/archive/category/logs.html
@@ -31,6 +31,7 @@
 <body id="archive-category-logs-page">
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
 
+    <div id="container">
     <!-- ### ヘッダー ### -->
     <header class="main-header">
         <div class="main-header__inner">
@@ -251,5 +252,6 @@
                 href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
         </div>
     </footer>
+    </div>
 </body>
 </html>

--- a/src/archive/date/entries.html
+++ b/src/archive/date/entries.html
@@ -31,6 +31,7 @@
 <body id="archive-date-entries-page">
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
 
+    <div id="container">
     <!-- ### ヘッダー ### -->
     <header class="main-header">
         <div class="main-header__inner">
@@ -251,5 +252,6 @@
                 href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
         </div>
     </footer>
+    </div>
 </body>
 </html>

--- a/src/archive/date/entries.html
+++ b/src/archive/date/entries.html
@@ -28,7 +28,7 @@
     <!-- ### その他の読み込みタグ（JS・CSS等） ### -->
 </head>
 
-<body id="archive-date-entries-page">
+<body>
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
 
     <div id="container">

--- a/src/archive/date/logs.html
+++ b/src/archive/date/logs.html
@@ -31,6 +31,7 @@
 <body id="archive-date-logs-page">
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
 
+    <div id="container">
     <!-- ### ヘッダー ### -->
     <header class="main-header">
         <div class="main-header__inner">
@@ -251,5 +252,6 @@
                 href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
         </div>
     </footer>
+    </div>
 </body>
 </html>

--- a/src/archive/date/logs.html
+++ b/src/archive/date/logs.html
@@ -28,7 +28,7 @@
     <!-- ### その他の読み込みタグ（JS・CSS等） ### -->
 </head>
 
-<body id="archive-date-logs-page">
+<body>
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
 
     <div id="container">

--- a/src/archive/tag/entries.html
+++ b/src/archive/tag/entries.html
@@ -31,6 +31,7 @@
 <body id="archive-tag-entries-page">
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
 
+    <div id="container">
     <!-- ### ヘッダー ### -->
     <header class="main-header">
         <div class="main-header__inner">
@@ -251,5 +252,6 @@
                 href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
         </div>
     </footer>
+    </div>
 </body>
 </html>

--- a/src/archive/tag/entries.html
+++ b/src/archive/tag/entries.html
@@ -28,7 +28,7 @@
     <!-- ### その他の読み込みタグ（JS・CSS等） ### -->
 </head>
 
-<body id="archive-tag-entries-page">
+<body>
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
 
     <div id="container">

--- a/src/archive/tag/logs.html
+++ b/src/archive/tag/logs.html
@@ -31,6 +31,7 @@
 <body id="archive-tag-logs-page">
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
 
+    <div id="container">
     <!-- ### ヘッダー ### -->
     <header class="main-header">
         <div class="main-header__inner">
@@ -251,5 +252,6 @@
                 href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
         </div>
     </footer>
+    </div>
 </body>
 </html>

--- a/src/archive/tag/logs.html
+++ b/src/archive/tag/logs.html
@@ -28,7 +28,7 @@
     <!-- ### その他の読み込みタグ（JS・CSS等） ### -->
 </head>
 
-<body id="archive-tag-logs-page">
+<body>
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
 
     <div id="container">

--- a/src/commons.html
+++ b/src/commons.html
@@ -32,6 +32,7 @@
 <body id="top-page">
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
 
+    <div id="container">
     <!-- ### ヘッダー ### -->
     <header class="main-header">
         <div class="main-header__inner">
@@ -102,6 +103,7 @@
                     class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
         </div>
     </footer>
+    </div>
 </body>
 
 </html>

--- a/src/commons.html
+++ b/src/commons.html
@@ -29,7 +29,7 @@
     <!-- ### その他の読み込みタグ（JS・CSS等） ### -->
 </head>
 
-<body id="top-page">
+<body>
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
 
     <div id="container">

--- a/src/entries/entry.html
+++ b/src/entries/entry.html
@@ -28,7 +28,7 @@
     <!-- ### その他の読み込みタグ（JS・CSS等） ### -->
 </head>
 
-<body id="entry-page">
+<body>
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
 
     <div id="container">

--- a/src/entries/entry.html
+++ b/src/entries/entry.html
@@ -31,6 +31,7 @@
 <body id="entry-page">
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
 
+    <div id="container">
     <!-- ### ヘッダー ### -->
     <header class="main-header">
         <div class="main-header__inner">
@@ -300,5 +301,6 @@
                 href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
         </div>
     </footer>
+    </div>
 </body>
 </html>

--- a/src/entries/index.html
+++ b/src/entries/index.html
@@ -28,7 +28,7 @@
     <!-- ### その他の読み込みタグ（JS・CSS等） ### -->
 </head>
 
-<body id="entries-page">
+<body>
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
 
     <div id="container">

--- a/src/entries/index.html
+++ b/src/entries/index.html
@@ -31,6 +31,7 @@
 <body id="entries-page">
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
 
+    <div id="container">
     <!-- ### ヘッダー ### -->
     <header class="main-header">
         <div class="main-header__inner">
@@ -246,5 +247,6 @@
                 href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
         </div>
     </footer>
+    </div>
 </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -28,7 +28,7 @@
     <!-- ### その他の読み込みタグ（JS・CSS等） ### -->
 </head>
 
-<body id="top-page">
+<body>
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
 
     <div id="container">

--- a/src/index.html
+++ b/src/index.html
@@ -31,6 +31,7 @@
 <body id="top-page">
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
 
+    <div id="container">
     <!-- ### ヘッダー ### -->
     <header class="main-header">
         <div class="main-header__inner">
@@ -246,5 +247,6 @@
                 href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
         </div>
     </footer>
+    </div>
 </body>
 </html>

--- a/src/logs/index.html
+++ b/src/logs/index.html
@@ -28,7 +28,7 @@
     <!-- ### その他の読み込みタグ（JS・CSS等） ### -->
 </head>
 
-<body id="logs-page">
+<body>
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
 
     <div id="container">

--- a/src/logs/index.html
+++ b/src/logs/index.html
@@ -31,6 +31,7 @@
 <body id="logs-page">
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
 
+    <div id="container">
     <!-- ### ヘッダー ### -->
     <header class="main-header">
         <div class="main-header__inner">
@@ -246,5 +247,6 @@
                 href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
         </div>
     </footer>
+    </div>
 </body>
 </html>

--- a/src/logs/log.html
+++ b/src/logs/log.html
@@ -28,7 +28,7 @@
     <!-- ### その他の読み込みタグ（JS・CSS等） ### -->
 </head>
 
-<body id="log-page">
+<body>
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
 
     <div id="container">

--- a/src/logs/log.html
+++ b/src/logs/log.html
@@ -31,6 +31,7 @@
 <body id="log-page">
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
 
+    <div id="container">
     <!-- ### ヘッダー ### -->
     <header class="main-header">
         <div class="main-header__inner">
@@ -300,5 +301,6 @@
                 href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
         </div>
     </footer>
+    </div>
 </body>
 </html>

--- a/src/search/entries.html
+++ b/src/search/entries.html
@@ -28,7 +28,7 @@
     <!-- ### その他の読み込みタグ（JS・CSS等） ### -->
 </head>
 
-<body id="search-entries-page">
+<body>
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
     
     <div id="container">

--- a/src/search/entries.html
+++ b/src/search/entries.html
@@ -31,6 +31,7 @@
 <body id="search-entries-page">
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
     
+    <div id="container">
     <!-- ### ヘッダー ### -->
     <header class="main-header">
         <div class="main-header__inner">
@@ -251,5 +252,6 @@
                 href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
         </div>
     </footer>
+    </div>
 </body>
 </html>

--- a/src/search/logs.html
+++ b/src/search/logs.html
@@ -31,6 +31,7 @@
 <body id="search-logs-page">
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
 
+    <div id="container">
     <!-- ### ヘッダー ### -->
     <header class="main-header">
         <div class="main-header__inner">
@@ -251,5 +252,6 @@
                 href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
         </div>
     </footer>
+    </div>
 </body>
 </html>

--- a/src/search/logs.html
+++ b/src/search/logs.html
@@ -28,7 +28,7 @@
     <!-- ### その他の読み込みタグ（JS・CSS等） ### -->
 </head>
 
-<body id="search-logs-page">
+<body>
     <!-- ### Qrunch グローバルヘッダー（変更不可） ### -->
 
     <div id="container">


### PR DESCRIPTION
### 概要
実際のブログで出力されている HTML と見比べたところ、下記の差異を見つけました。

1. 実際のブログは body タグの直下に id="container" の div タグが存在し、ヘッダー、メインコンテント、サブコンテント、フッターをまとめている。
2. 実際のブログはどのページの body タグにも id がついていない。

そのためこれらの差異をテンプレートに反映しました。