### PR TITLE
サブコンテント部のクラス名等を修正

### DIFF
--- a/src/archive/category/entries.html
+++ b/src/archive/category/entries.html
@@ -141,8 +141,7 @@
                     <div class="sub-content__inner">
 
                         <!-- ### ブログ内検索 ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-search-module">
+                            <div class="side-module side-search-module">
                                 <h3 class="side-module__title">検索</h3>
                                 <div class="side-module__content">
                                     <form class="side-module__form" method="get" action="/search">
@@ -150,11 +149,9 @@
                                     </form>
                                 </div>
                             </div>
-                        </div>
 
                         <!-- ### プロフィール ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-search-module">
+                            <div class="side-module side-profile-module">
                                 <h3 class="side-module__title">プロフィール</h3>
                                 <div class="side-module__content">
                                     <a href="{{ Profile URL }}" target="_blank" class="side-module__profile-icon-link">
@@ -167,17 +164,15 @@
                                     <div class="side-module__profile-description">{{ Profile Description }}</div>
                                 </div>
                             </div>
-                        </div>
 
                         <!-- ### 記事カテゴリー ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-category-module">
-                                <h3 class="side-module__title">カテゴリー</h3>
+                            <div class="side-module side-category-module">
+                                <h3 class="side-module__title">カテゴリ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__categories">
                                         <li class="side-module__category-item">
                                             <a href="{{ Category URL }}" class="side-module__category-item-link">
-                                                <span class="side-module__category-item-month">{{ Category Name }}</span>
+                                                <span class="side-module__category-item-name">{{ Category Name }}</span>
                                                 <span class="side-module__category-item-count">（{{ Category Count }}）</span>
                                             </a>
                                         </li>
@@ -188,12 +183,10 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>    
                         
                         <!-- ### 記事タグ ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-tag-module">
-                                <h3 class="side-module__title">カテゴリー</h3>
+                            <div class="side-module side-tag-module">
+                                <h3 class="side-module__title">よく使うタグ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__tags">
                                         <li class="side-module__tag-item">
@@ -206,17 +199,15 @@
                                     </div>
                                 </div>
                             </div>
-                        </div> 
 
                         <!-- ### 月別アーカイブ ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-monthly-archive-module">
+                            <div class="side-module side-monthly-archive-module">
                                 <h3 class="side-module__title">月別アーカイブ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__monthly-archives">
                                         <li class="side-module__monthly-archive-item">
                                             <a href="{{ Archive URL }}" class="side-module__monthly-archive-item-link">
-                                                <span class="side-module__monthly-archive-item-month">{{ Archive Year }}-{{ Archive Month }}</span>
+                                                <span class="side-module__monthly-archive-item-name">{{ Archive Year }}-{{ Archive Month }}</span>
                                                 <span class="side-module__monthly-archive-item-count">({{ Archive Count }})</span>
                                             </a>
                                         </li>
@@ -227,7 +218,6 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>
 
                     </div>
                 </aside>

--- a/src/archive/category/logs.html
+++ b/src/archive/category/logs.html
@@ -141,8 +141,7 @@
                     <div class="sub-content__inner">
 
                         <!-- ### ブログ内検索 ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-search-module">
+                            <div class="side-module side-search-module">
                                 <h3 class="side-module__title">検索</h3>
                                 <div class="side-module__content">
                                     <form class="side-module__form" method="get" action="/search">
@@ -150,11 +149,9 @@
                                     </form>
                                 </div>
                             </div>
-                        </div>
 
                         <!-- ### プロフィール ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-search-module">
+                            <div class="side-module side-profile-module">
                                 <h3 class="side-module__title">プロフィール</h3>
                                 <div class="side-module__content">
                                     <a href="{{ Profile URL }}" target="_blank" class="side-module__profile-icon-link">
@@ -167,17 +164,15 @@
                                     <div class="side-module__profile-description">{{ Profile Description }}</div>
                                 </div>
                             </div>
-                        </div>
 
                         <!-- ### 記事カテゴリー ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-category-module">
-                                <h3 class="side-module__title">カテゴリー</h3>
+                            <div class="side-module side-category-module">
+                                <h3 class="side-module__title">カテゴリ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__categories">
                                         <li class="side-module__category-item">
                                             <a href="{{ Category URL }}" class="side-module__category-item-link">
-                                                <span class="side-module__category-item-month">{{ Category Name }}</span>
+                                                <span class="side-module__category-item-name">{{ Category Name }}</span>
                                                 <span class="side-module__category-item-count">（{{ Category Count }}）</span>
                                             </a>
                                         </li>
@@ -188,12 +183,10 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>    
                         
                         <!-- ### 記事タグ ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-tag-module">
-                                <h3 class="side-module__title">カテゴリー</h3>
+                            <div class="side-module side-tag-module">
+                                <h3 class="side-module__title">よく使うタグ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__tags">
                                         <li class="side-module__tag-item">
@@ -206,17 +199,15 @@
                                     </div>
                                 </div>
                             </div>
-                        </div> 
 
                         <!-- ### 月別アーカイブ ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-monthly-archive-module">
+                            <div class="side-module side-monthly-archive-module">
                                 <h3 class="side-module__title">月別アーカイブ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__monthly-archives">
                                         <li class="side-module__monthly-archive-item">
                                             <a href="{{ Archive URL }}" class="side-module__monthly-archive-item-link">
-                                                <span class="side-module__monthly-archive-item-month">{{ Archive Year }}-{{ Archive Month }}</span>
+                                                <span class="side-module__monthly-archive-item-name">{{ Archive Year }}-{{ Archive Month }}</span>
                                                 <span class="side-module__monthly-archive-item-count">({{ Archive Count }})</span>
                                             </a>
                                         </li>
@@ -227,7 +218,6 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>
 
                     </div>
                 </aside>

--- a/src/archive/date/entries.html
+++ b/src/archive/date/entries.html
@@ -141,8 +141,7 @@
                     <div class="sub-content__inner">
 
                         <!-- ### ブログ内検索 ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-search-module">
+                            <div class="side-module side-search-module">
                                 <h3 class="side-module__title">検索</h3>
                                 <div class="side-module__content">
                                     <form class="side-module__form" method="get" action="/search">
@@ -150,11 +149,9 @@
                                     </form>
                                 </div>
                             </div>
-                        </div>
 
                         <!-- ### プロフィール ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-search-module">
+                            <div class="side-module side-profile-module">
                                 <h3 class="side-module__title">プロフィール</h3>
                                 <div class="side-module__content">
                                     <a href="{{ Profile URL }}" target="_blank" class="side-module__profile-icon-link">
@@ -167,17 +164,15 @@
                                     <div class="side-module__profile-description">{{ Profile Description }}</div>
                                 </div>
                             </div>
-                        </div>
 
                         <!-- ### 記事カテゴリー ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-category-module">
-                                <h3 class="side-module__title">カテゴリー</h3>
+                            <div class="side-module side-category-module">
+                                <h3 class="side-module__title">カテゴリ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__categories">
                                         <li class="side-module__category-item">
                                             <a href="{{ Category URL }}" class="side-module__category-item-link">
-                                                <span class="side-module__category-item-month">{{ Category Name }}</span>
+                                                <span class="side-module__category-item-name">{{ Category Name }}</span>
                                                 <span class="side-module__category-item-count">（{{ Category Count }}）</span>
                                             </a>
                                         </li>
@@ -188,12 +183,10 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>    
                         
                         <!-- ### 記事タグ ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-tag-module">
-                                <h3 class="side-module__title">カテゴリー</h3>
+                            <div class="side-module side-tag-module">
+                                <h3 class="side-module__title">よく使うタグ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__tags">
                                         <li class="side-module__tag-item">
@@ -206,17 +199,15 @@
                                     </div>
                                 </div>
                             </div>
-                        </div> 
 
                         <!-- ### 月別アーカイブ ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-monthly-archive-module">
+                            <div class="side-module side-monthly-archive-module">
                                 <h3 class="side-module__title">月別アーカイブ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__monthly-archives">
                                         <li class="side-module__monthly-archive-item">
                                             <a href="{{ Archive URL }}" class="side-module__monthly-archive-item-link">
-                                                <span class="side-module__monthly-archive-item-month">{{ Archive Year }}-{{ Archive Month }}</span>
+                                                <span class="side-module__monthly-archive-item-name">{{ Archive Year }}-{{ Archive Month }}</span>
                                                 <span class="side-module__monthly-archive-item-count">({{ Archive Count }})</span>
                                             </a>
                                         </li>
@@ -227,7 +218,6 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>
 
                     </div>
                 </aside>

--- a/src/archive/date/logs.html
+++ b/src/archive/date/logs.html
@@ -141,8 +141,7 @@
                     <div class="sub-content__inner">
 
                         <!-- ### ブログ内検索 ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-search-module">
+                            <div class="side-module side-search-module">
                                 <h3 class="side-module__title">検索</h3>
                                 <div class="side-module__content">
                                     <form class="side-module__form" method="get" action="/search">
@@ -150,11 +149,9 @@
                                     </form>
                                 </div>
                             </div>
-                        </div>
 
                         <!-- ### プロフィール ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-search-module">
+                            <div class="side-module side-profile-module">
                                 <h3 class="side-module__title">プロフィール</h3>
                                 <div class="side-module__content">
                                     <a href="{{ Profile URL }}" target="_blank" class="side-module__profile-icon-link">
@@ -167,17 +164,15 @@
                                     <div class="side-module__profile-description">{{ Profile Description }}</div>
                                 </div>
                             </div>
-                        </div>
 
                         <!-- ### 記事カテゴリー ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-category-module">
-                                <h3 class="side-module__title">カテゴリー</h3>
+                            <div class="side-module side-category-module">
+                                <h3 class="side-module__title">カテゴリ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__categories">
                                         <li class="side-module__category-item">
                                             <a href="{{ Category URL }}" class="side-module__category-item-link">
-                                                <span class="side-module__category-item-month">{{ Category Name }}</span>
+                                                <span class="side-module__category-item-name">{{ Category Name }}</span>
                                                 <span class="side-module__category-item-count">（{{ Category Count }}）</span>
                                             </a>
                                         </li>
@@ -188,12 +183,10 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>    
                         
                         <!-- ### 記事タグ ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-tag-module">
-                                <h3 class="side-module__title">カテゴリー</h3>
+                            <div class="side-module side-tag-module">
+                                <h3 class="side-module__title">よく使うタグ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__tags">
                                         <li class="side-module__tag-item">
@@ -206,17 +199,15 @@
                                     </div>
                                 </div>
                             </div>
-                        </div> 
 
                         <!-- ### 月別アーカイブ ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-monthly-archive-module">
+                            <div class="side-module side-monthly-archive-module">
                                 <h3 class="side-module__title">月別アーカイブ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__monthly-archives">
                                         <li class="side-module__monthly-archive-item">
                                             <a href="{{ Archive URL }}" class="side-module__monthly-archive-item-link">
-                                                <span class="side-module__monthly-archive-item-month">{{ Archive Year }}-{{ Archive Month }}</span>
+                                                <span class="side-module__monthly-archive-item-name">{{ Archive Year }}-{{ Archive Month }}</span>
                                                 <span class="side-module__monthly-archive-item-count">({{ Archive Count }})</span>
                                             </a>
                                         </li>
@@ -227,7 +218,6 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>
 
                     </div>
                 </aside>

--- a/src/archive/tag/entries.html
+++ b/src/archive/tag/entries.html
@@ -141,8 +141,7 @@
                     <div class="sub-content__inner">
 
                         <!-- ### ブログ内検索 ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-search-module">
+                            <div class="side-module side-search-module">
                                 <h3 class="side-module__title">検索</h3>
                                 <div class="side-module__content">
                                     <form class="side-module__form" method="get" action="/search">
@@ -150,11 +149,9 @@
                                     </form>
                                 </div>
                             </div>
-                        </div>
 
                         <!-- ### プロフィール ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-search-module">
+                            <div class="side-module side-profile-module">
                                 <h3 class="side-module__title">プロフィール</h3>
                                 <div class="side-module__content">
                                     <a href="{{ Profile URL }}" target="_blank" class="side-module__profile-icon-link">
@@ -167,17 +164,15 @@
                                     <div class="side-module__profile-description">{{ Profile Description }}</div>
                                 </div>
                             </div>
-                        </div>
 
                         <!-- ### 記事カテゴリー ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-category-module">
-                                <h3 class="side-module__title">カテゴリー</h3>
+                            <div class="side-module side-category-module">
+                                <h3 class="side-module__title">カテゴリ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__categories">
                                         <li class="side-module__category-item">
                                             <a href="{{ Category URL }}" class="side-module__category-item-link">
-                                                <span class="side-module__category-item-month">{{ Category Name }}</span>
+                                                <span class="side-module__category-item-name">{{ Category Name }}</span>
                                                 <span class="side-module__category-item-count">（{{ Category Count }}）</span>
                                             </a>
                                         </li>
@@ -187,13 +182,11 @@
                                         <span>データなし</span>
                                     </div>
                                 </div>
-                            </div>
-                        </div>    
+                            </div> 
                         
                         <!-- ### 記事タグ ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-tag-module">
-                                <h3 class="side-module__title">カテゴリー</h3>
+                            <div class="side-module side-tag-module">
+                                <h3 class="side-module__title">よく使うタグ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__tags">
                                         <li class="side-module__tag-item">
@@ -206,17 +199,15 @@
                                     </div>
                                 </div>
                             </div>
-                        </div> 
 
                         <!-- ### 月別アーカイブ ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-monthly-archive-module">
+                            <div class="side-module side-monthly-archive-module">
                                 <h3 class="side-module__title">月別アーカイブ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__monthly-archives">
                                         <li class="side-module__monthly-archive-item">
                                             <a href="{{ Archive URL }}" class="side-module__monthly-archive-item-link">
-                                                <span class="side-module__monthly-archive-item-month">{{ Archive Year }}-{{ Archive Month }}</span>
+                                                <span class="side-module__monthly-archive-item-name">{{ Archive Year }}-{{ Archive Month }}</span>
                                                 <span class="side-module__monthly-archive-item-count">({{ Archive Count }})</span>
                                             </a>
                                         </li>
@@ -227,7 +218,6 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>
 
                     </div>
                 </aside>

--- a/src/archive/tag/logs.html
+++ b/src/archive/tag/logs.html
@@ -141,8 +141,7 @@
                     <div class="sub-content__inner">
 
                         <!-- ### ブログ内検索 ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-search-module">
+                            <div class="side-module side-search-module">
                                 <h3 class="side-module__title">検索</h3>
                                 <div class="side-module__content">
                                     <form class="side-module__form" method="get" action="/search">
@@ -150,11 +149,9 @@
                                     </form>
                                 </div>
                             </div>
-                        </div>
 
                         <!-- ### プロフィール ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-search-module">
+                            <div class="side-module side-profile-module">
                                 <h3 class="side-module__title">プロフィール</h3>
                                 <div class="side-module__content">
                                     <a href="{{ Profile URL }}" target="_blank" class="side-module__profile-icon-link">
@@ -167,17 +164,15 @@
                                     <div class="side-module__profile-description">{{ Profile Description }}</div>
                                 </div>
                             </div>
-                        </div>
 
                         <!-- ### 記事カテゴリー ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-category-module">
-                                <h3 class="side-module__title">カテゴリー</h3>
+                            <div class="side-module side-category-module">
+                                <h3 class="side-module__title">カテゴリ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__categories">
                                         <li class="side-module__category-item">
                                             <a href="{{ Category URL }}" class="side-module__category-item-link">
-                                                <span class="side-module__category-item-month">{{ Category Name }}</span>
+                                                <span class="side-module__category-item-name">{{ Category Name }}</span>
                                                 <span class="side-module__category-item-count">（{{ Category Count }}）</span>
                                             </a>
                                         </li>
@@ -188,12 +183,10 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>    
                         
                         <!-- ### 記事タグ ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-tag-module">
-                                <h3 class="side-module__title">カテゴリー</h3>
+                            <div class="side-module side-tag-module">
+                                <h3 class="side-module__title">よく使うタグ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__tags">
                                         <li class="side-module__tag-item">
@@ -206,17 +199,15 @@
                                     </div>
                                 </div>
                             </div>
-                        </div> 
 
                         <!-- ### 月別アーカイブ ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-monthly-archive-module">
+                            <div class="side-module side-monthly-archive-module">
                                 <h3 class="side-module__title">月別アーカイブ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__monthly-archives">
                                         <li class="side-module__monthly-archive-item">
                                             <a href="{{ Archive URL }}" class="side-module__monthly-archive-item-link">
-                                                <span class="side-module__monthly-archive-item-month">{{ Archive Year }}-{{ Archive Month }}</span>
+                                                <span class="side-module__monthly-archive-item-name">{{ Archive Year }}-{{ Archive Month }}</span>
                                                 <span class="side-module__monthly-archive-item-count">({{ Archive Count }})</span>
                                             </a>
                                         </li>
@@ -227,7 +218,6 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>
 
                     </div>
                 </aside>

--- a/src/entries/entry.html
+++ b/src/entries/entry.html
@@ -190,8 +190,7 @@
                     <div class="sub-content__inner">
 
                         <!-- ### ブログ内検索 ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-search-module">
+                            <div class="side-module side-search-module">
                                 <h3 class="side-module__title">検索</h3>
                                 <div class="side-module__content">
                                     <form class="side-module__form" method="get" action="/search">
@@ -199,11 +198,9 @@
                                     </form>
                                 </div>
                             </div>
-                        </div>
 
                         <!-- ### プロフィール ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-search-module">
+                            <div class="side-module side-profile-module">
                                 <h3 class="side-module__title">プロフィール</h3>
                                 <div class="side-module__content">
                                     <a href="{{ Profile URL }}" target="_blank" class="side-module__profile-icon-link">
@@ -216,17 +213,15 @@
                                     <div class="side-module__profile-description">{{ Profile Description }}</div>
                                 </div>
                             </div>
-                        </div>
 
                         <!-- ### 記事カテゴリー ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-category-module">
-                                <h3 class="side-module__title">カテゴリー</h3>
+                            <div class="side-module side-category-module">
+                                <h3 class="side-module__title">カテゴリ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__categories">
                                         <li class="side-module__category-item">
                                             <a href="{{ Category URL }}" class="side-module__category-item-link">
-                                                <span class="side-module__category-item-month">{{ Category Name }}</span>
+                                                <span class="side-module__category-item-name">{{ Category Name }}</span>
                                                 <span class="side-module__category-item-count">（{{ Category Count }}）</span>
                                             </a>
                                         </li>
@@ -237,12 +232,10 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>    
                         
                         <!-- ### 記事タグ ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-tag-module">
-                                <h3 class="side-module__title">カテゴリー</h3>
+                            <div class="side-module side-tag-module">
+                                <h3 class="side-module__title">よく使うタグ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__tags">
                                         <li class="side-module__tag-item">
@@ -255,17 +248,15 @@
                                     </div>
                                 </div>
                             </div>
-                        </div> 
 
                         <!-- ### 月別アーカイブ ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-monthly-archive-module">
+                            <div class="side-module side-monthly-archive-module">
                                 <h3 class="side-module__title">月別アーカイブ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__monthly-archives">
                                         <li class="side-module__monthly-archive-item">
                                             <a href="{{ Archive URL }}" class="side-module__monthly-archive-item-link">
-                                                <span class="side-module__monthly-archive-item-month">{{ Archive Year }}-{{ Archive Month }}</span>
+                                                <span class="side-module__monthly-archive-item-name">{{ Archive Year }}-{{ Archive Month }}</span>
                                                 <span class="side-module__monthly-archive-item-count">({{ Archive Count }})</span>
                                             </a>
                                         </li>
@@ -276,7 +267,6 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>
 
                     </div>
                 </aside>

--- a/src/entries/index.html
+++ b/src/entries/index.html
@@ -136,8 +136,7 @@
                     <div class="sub-content__inner">
 
                         <!-- ### ブログ内検索 ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-search-module">
+                            <div class="side-module side-search-module">
                                 <h3 class="side-module__title">検索</h3>
                                 <div class="side-module__content">
                                     <form class="side-module__form" method="get" action="/search">
@@ -145,11 +144,9 @@
                                     </form>
                                 </div>
                             </div>
-                        </div>
 
                         <!-- ### プロフィール ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-search-module">
+                            <div class="side-module side-profile-module">
                                 <h3 class="side-module__title">プロフィール</h3>
                                 <div class="side-module__content">
                                     <a href="{{ Profile URL }}" target="_blank" class="side-module__profile-icon-link">
@@ -162,17 +159,15 @@
                                     <div class="side-module__profile-description">{{ Profile Description }}</div>
                                 </div>
                             </div>
-                        </div>
 
                         <!-- ### 記事カテゴリー ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-category-module">
-                                <h3 class="side-module__title">カテゴリー</h3>
+                            <div class="side-module side-category-module">
+                                <h3 class="side-module__title">カテゴリ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__categories">
                                         <li class="side-module__category-item">
                                             <a href="{{ Category URL }}" class="side-module__category-item-link">
-                                                <span class="side-module__category-item-month">{{ Category Name }}</span>
+                                                <span class="side-module__category-item-name">{{ Category Name }}</span>
                                                 <span class="side-module__category-item-count">（{{ Category Count }}）</span>
                                             </a>
                                         </li>
@@ -183,12 +178,10 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>    
                         
                         <!-- ### 記事タグ ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-tag-module">
-                                <h3 class="side-module__title">カテゴリー</h3>
+                            <div class="side-module side-tag-module">
+                                <h3 class="side-module__title">よく使うタグ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__tags">
                                         <li class="side-module__tag-item">
@@ -201,17 +194,15 @@
                                     </div>
                                 </div>
                             </div>
-                        </div> 
 
                         <!-- ### 月別アーカイブ ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-monthly-archive-module">
+                            <div class="side-module side-monthly-archive-module">
                                 <h3 class="side-module__title">月別アーカイブ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__monthly-archives">
                                         <li class="side-module__monthly-archive-item">
                                             <a href="{{ Archive URL }}" class="side-module__monthly-archive-item-link">
-                                                <span class="side-module__monthly-archive-item-month">{{ Archive Year }}-{{ Archive Month }}</span>
+                                                <span class="side-module__monthly-archive-item-name">{{ Archive Year }}-{{ Archive Month }}</span>
                                                 <span class="side-module__monthly-archive-item-count">({{ Archive Count }})</span>
                                             </a>
                                         </li>
@@ -222,7 +213,6 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>
 
                     </div>
                 </aside>

--- a/src/index.html
+++ b/src/index.html
@@ -136,8 +136,7 @@
                     <div class="sub-content__inner">
 
                         <!-- ### ブログ内検索 ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-search-module">
+                            <div class="side-module side-search-module">
                                 <h3 class="side-module__title">検索</h3>
                                 <div class="side-module__content">
                                     <form class="side-module__form" method="get" action="/search">
@@ -145,11 +144,9 @@
                                     </form>
                                 </div>
                             </div>
-                        </div>
 
                         <!-- ### プロフィール ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-search-module">
+                            <div class="side-module side-profile-module">
                                 <h3 class="side-module__title">プロフィール</h3>
                                 <div class="side-module__content">
                                     <a href="{{ Profile URL }}" target="_blank" class="side-module__profile-icon-link">
@@ -162,17 +159,15 @@
                                     <div class="side-module__profile-description">{{ Profile Description }}</div>
                                 </div>
                             </div>
-                        </div>
 
                         <!-- ### 記事カテゴリー ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-category-module">
-                                <h3 class="side-module__title">カテゴリー</h3>
+                            <div class="side-module side-category-module">
+                                <h3 class="side-module__title">カテゴリ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__categories">
                                         <li class="side-module__category-item">
                                             <a href="{{ Category URL }}" class="side-module__category-item-link">
-                                                <span class="side-module__category-item-month">{{ Category Name }}</span>
+                                                <span class="side-module__category-item-name">{{ Category Name }}</span>
                                                 <span class="side-module__category-item-count">（{{ Category Count }}）</span>
                                             </a>
                                         </li>
@@ -182,13 +177,11 @@
                                         <span>データなし</span>
                                     </div>
                                 </div>
-                            </div>
-                        </div>    
+                            </div>  
                         
                         <!-- ### 記事タグ ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-tag-module">
-                                <h3 class="side-module__title">カテゴリー</h3>
+                            <div class="side-module side-tag-module">
+                                <h3 class="side-module__title">よく使うタグ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__tags">
                                         <li class="side-module__tag-item">
@@ -201,17 +194,15 @@
                                     </div>
                                 </div>
                             </div>
-                        </div> 
 
                         <!-- ### 月別アーカイブ ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-monthly-archive-module">
+                            <div class="side-module side-monthly-archive-module">
                                 <h3 class="side-module__title">月別アーカイブ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__monthly-archives">
                                         <li class="side-module__monthly-archive-item">
                                             <a href="{{ Archive URL }}" class="side-module__monthly-archive-item-link">
-                                                <span class="side-module__monthly-archive-item-month">{{ Archive Year }}-{{ Archive Month }}</span>
+                                                <span class="side-module__monthly-archive-item-name">{{ Archive Year }}-{{ Archive Month }}</span>
                                                 <span class="side-module__monthly-archive-item-count">({{ Archive Count }})</span>
                                             </a>
                                         </li>
@@ -222,7 +213,6 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>
 
                     </div>
                 </aside>

--- a/src/logs/index.html
+++ b/src/logs/index.html
@@ -136,8 +136,7 @@
                     <div class="sub-content__inner">
 
                         <!-- ### ブログ内検索 ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-search-module">
+                            <div class="side-module side-search-module">
                                 <h3 class="side-module__title">検索</h3>
                                 <div class="side-module__content">
                                     <form class="side-module__form" method="get" action="/search">
@@ -145,11 +144,9 @@
                                     </form>
                                 </div>
                             </div>
-                        </div>
 
                         <!-- ### プロフィール ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-search-module">
+                            <div class="side-module side-profile-module">
                                 <h3 class="side-module__title">プロフィール</h3>
                                 <div class="side-module__content">
                                     <a href="{{ Profile URL }}" target="_blank" class="side-module__profile-icon-link">
@@ -162,17 +159,15 @@
                                     <div class="side-module__profile-description">{{ Profile Description }}</div>
                                 </div>
                             </div>
-                        </div>
 
                         <!-- ### 記事カテゴリー ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-category-module">
-                                <h3 class="side-module__title">カテゴリー</h3>
+                            <div class="side-module side-category-module">
+                                <h3 class="side-module__title">カテゴリ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__categories">
                                         <li class="side-module__category-item">
                                             <a href="{{ Category URL }}" class="side-module__category-item-link">
-                                                <span class="side-module__category-item-month">{{ Category Name }}</span>
+                                                <span class="side-module__category-item-name">{{ Category Name }}</span>
                                                 <span class="side-module__category-item-count">（{{ Category Count }}）</span>
                                             </a>
                                         </li>
@@ -183,12 +178,10 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>    
                         
                         <!-- ### 記事タグ ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-tag-module">
-                                <h3 class="side-module__title">カテゴリー</h3>
+                            <div class="side-module side-tag-module">
+                                <h3 class="side-module__title">よく使うタグ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__tags">
                                         <li class="side-module__tag-item">
@@ -201,17 +194,15 @@
                                     </div>
                                 </div>
                             </div>
-                        </div> 
 
                         <!-- ### 月別アーカイブ ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-monthly-archive-module">
+                            <div class="side-module side-monthly-archive-module">
                                 <h3 class="side-module__title">月別アーカイブ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__monthly-archives">
                                         <li class="side-module__monthly-archive-item">
                                             <a href="{{ Archive URL }}" class="side-module__monthly-archive-item-link">
-                                                <span class="side-module__monthly-archive-item-month">{{ Archive Year }}-{{ Archive Month }}</span>
+                                                <span class="side-module__monthly-archive-item-name">{{ Archive Year }}-{{ Archive Month }}</span>
                                                 <span class="side-module__monthly-archive-item-count">({{ Archive Count }})</span>
                                             </a>
                                         </li>
@@ -222,7 +213,6 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>
 
                     </div>
                 </aside>

--- a/src/logs/log.html
+++ b/src/logs/log.html
@@ -190,8 +190,7 @@
                     <div class="sub-content__inner">
 
                         <!-- ### ブログ内検索 ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-search-module">
+                            <div class="side-module side-search-module">
                                 <h3 class="side-module__title">検索</h3>
                                 <div class="side-module__content">
                                     <form class="side-module__form" method="get" action="/search">
@@ -199,11 +198,9 @@
                                     </form>
                                 </div>
                             </div>
-                        </div>
 
                         <!-- ### プロフィール ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-search-module">
+                            <div class="side-module side-profile-module">
                                 <h3 class="side-module__title">プロフィール</h3>
                                 <div class="side-module__content">
                                     <a href="{{ Profile URL }}" target="_blank" class="side-module__profile-icon-link">
@@ -216,17 +213,15 @@
                                     <div class="side-module__profile-description">{{ Profile Description }}</div>
                                 </div>
                             </div>
-                        </div>
 
                         <!-- ### 記事カテゴリー ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-category-module">
-                                <h3 class="side-module__title">カテゴリー</h3>
+                            <div class="side-module side-category-module">
+                                <h3 class="side-module__title">カテゴリ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__categories">
                                         <li class="side-module__category-item">
                                             <a href="{{ Category URL }}" class="side-module__category-item-link">
-                                                <span class="side-module__category-item-month">{{ Category Name }}</span>
+                                                <span class="side-module__category-item-name">{{ Category Name }}</span>
                                                 <span class="side-module__category-item-count">（{{ Category Count }}）</span>
                                             </a>
                                         </li>
@@ -237,12 +232,10 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>    
                         
                         <!-- ### 記事タグ ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-tag-module">
-                                <h3 class="side-module__title">カテゴリー</h3>
+                            <div class="side-module side-tag-module">
+                                <h3 class="side-module__title">よく使うタグ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__tags">
                                         <li class="side-module__tag-item">
@@ -255,17 +248,15 @@
                                     </div>
                                 </div>
                             </div>
-                        </div> 
 
                         <!-- ### 月別アーカイブ ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-monthly-archive-module">
+                            <div class="side-module side-monthly-archive-module">
                                 <h3 class="side-module__title">月別アーカイブ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__monthly-archives">
                                         <li class="side-module__monthly-archive-item">
                                             <a href="{{ Archive URL }}" class="side-module__monthly-archive-item-link">
-                                                <span class="side-module__monthly-archive-item-month">{{ Archive Year }}-{{ Archive Month }}</span>
+                                                <span class="side-module__monthly-archive-item-name">{{ Archive Year }}-{{ Archive Month }}</span>
                                                 <span class="side-module__monthly-archive-item-count">({{ Archive Count }})</span>
                                             </a>
                                         </li>
@@ -276,7 +267,6 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>
 
                     </div>
                 </aside>

--- a/src/search/entries.html
+++ b/src/search/entries.html
@@ -141,8 +141,7 @@
                     <div class="sub-content__inner">
 
                         <!-- ### ブログ内検索 ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-search-module">
+                            <div class="side-module side-search-module">
                                 <h3 class="side-module__title">検索</h3>
                                 <div class="side-module__content">
                                     <form class="side-module__form" method="get" action="/search">
@@ -150,11 +149,9 @@
                                     </form>
                                 </div>
                             </div>
-                        </div>
 
                         <!-- ### プロフィール ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-search-module">
+                            <div class="side-module side-profile-module">
                                 <h3 class="side-module__title">プロフィール</h3>
                                 <div class="side-module__content">
                                     <a href="{{ Profile URL }}" target="_blank" class="side-module__profile-icon-link">
@@ -167,17 +164,15 @@
                                     <div class="side-module__profile-description">{{ Profile Description }}</div>
                                 </div>
                             </div>
-                        </div>
 
                         <!-- ### 記事カテゴリー ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-category-module">
-                                <h3 class="side-module__title">カテゴリー</h3>
+                            <div class="side-module side-category-module">
+                                <h3 class="side-module__title">カテゴリ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__categories">
                                         <li class="side-module__category-item">
                                             <a href="{{ Category URL }}" class="side-module__category-item-link">
-                                                <span class="side-module__category-item-month">{{ Category Name }}</span>
+                                                <span class="side-module__category-item-name">{{ Category Name }}</span>
                                                 <span class="side-module__category-item-count">（{{ Category Count }}）</span>
                                             </a>
                                         </li>
@@ -188,12 +183,10 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>    
                         
                         <!-- ### 記事タグ ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-tag-module">
-                                <h3 class="side-module__title">カテゴリー</h3>
+                            <div class="side-module side-tag-module">
+                                <h3 class="side-module__title">よく使うタグ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__tags">
                                         <li class="side-module__tag-item">
@@ -206,17 +199,15 @@
                                     </div>
                                 </div>
                             </div>
-                        </div> 
 
                         <!-- ### 月別アーカイブ ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-monthly-archive-module">
+                            <div class="side-module side-monthly-archive-module">
                                 <h3 class="side-module__title">月別アーカイブ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__monthly-archives">
                                         <li class="side-module__monthly-archive-item">
                                             <a href="{{ Archive URL }}" class="side-module__monthly-archive-item-link">
-                                                <span class="side-module__monthly-archive-item-month">{{ Archive Year }}-{{ Archive Month }}</span>
+                                                <span class="side-module__monthly-archive-item-name">{{ Archive Year }}-{{ Archive Month }}</span>
                                                 <span class="side-module__monthly-archive-item-count">({{ Archive Count }})</span>
                                             </a>
                                         </li>
@@ -227,7 +218,6 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>
 
                     </div>
                 </aside>

--- a/src/search/logs.html
+++ b/src/search/logs.html
@@ -141,8 +141,7 @@
                     <div class="sub-content__inner">
 
                         <!-- ### ブログ内検索 ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-search-module">
+                            <div class="side-module side-search-module">
                                 <h3 class="side-module__title">検索</h3>
                                 <div class="side-module__content">
                                     <form class="side-module__form" method="get" action="/search">
@@ -150,11 +149,9 @@
                                     </form>
                                 </div>
                             </div>
-                        </div>
 
                         <!-- ### プロフィール ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-search-module">
+                            <div class="side-module side-profile-module">
                                 <h3 class="side-module__title">プロフィール</h3>
                                 <div class="side-module__content">
                                     <a href="{{ Profile URL }}" target="_blank" class="side-module__profile-icon-link">
@@ -167,17 +164,15 @@
                                     <div class="side-module__profile-description">{{ Profile Description }}</div>
                                 </div>
                             </div>
-                        </div>
 
                         <!-- ### 記事カテゴリー ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-category-module">
-                                <h3 class="side-module__title">カテゴリー</h3>
+                            <div class="side-module side-category-module">
+                                <h3 class="side-module__title">カテゴリ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__categories">
                                         <li class="side-module__category-item">
                                             <a href="{{ Category URL }}" class="side-module__category-item-link">
-                                                <span class="side-module__category-item-month">{{ Category Name }}</span>
+                                                <span class="side-module__category-item-name">{{ Category Name }}</span>
                                                 <span class="side-module__category-item-count">（{{ Category Count }}）</span>
                                             </a>
                                         </li>
@@ -188,12 +183,10 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>    
                         
                         <!-- ### 記事タグ ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-tag-module">
-                                <h3 class="side-module__title">カテゴリー</h3>
+                            <div class="side-module side-tag-module">
+                                <h3 class="side-module__title">よく使うタグ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__tags">
                                         <li class="side-module__tag-item">
@@ -206,17 +199,15 @@
                                     </div>
                                 </div>
                             </div>
-                        </div> 
 
                         <!-- ### 月別アーカイブ ### -->
-                        <div class="sub-content__side-mudules">
-                            <div class="side-mudule side-monthly-archive-module">
+                            <div class="side-module side-monthly-archive-module">
                                 <h3 class="side-module__title">月別アーカイブ</h3>
                                 <div class="side-module__content">
                                     <ul class="side-module__monthly-archives">
                                         <li class="side-module__monthly-archive-item">
                                             <a href="{{ Archive URL }}" class="side-module__monthly-archive-item-link">
-                                                <span class="side-module__monthly-archive-item-month">{{ Archive Year }}-{{ Archive Month }}</span>
+                                                <span class="side-module__monthly-archive-item-name">{{ Archive Year }}-{{ Archive Month }}</span>
                                                 <span class="side-module__monthly-archive-item-count">({{ Archive Count }})</span>
                                             </a>
                                         </li>
@@ -227,7 +218,6 @@
                                     </div>
                                 </div>
                             </div>
-                        </div>
 
                     </div>
                 </aside>


### PR DESCRIPTION
サブコンテント部について、実際のブログとの差異が存在しました。

- `<div class="sub-content__side-mudules">` は実際には存在しない。
- side-m**u**dule というクラス名は実際には side-m**o**dule である。
- プロフィール部の div についている side-**search**-module というクラス名が実際には side-**profile**-module である。
- カテゴリ部のh3要素が「カテゴリ**ー**」となっていたが実際には「カテゴリ」である。
- カテゴリ部の div についている side-module__category-item-**month** というクラス名が実際には side-module__category-item-**name** である。
- よく使うタグ部の h3要素が「カテゴリー」になっていたが実際には「よく使うタグ」である。
- 月別アーカイブ部の div についている side-module__monthly-archive-item-**month** というクラス名が実際には side-module__monthly-archive-item-**name** である。

よってこれらを修正しました。