### PR TITLE
全ページの構造・クラス名修正

### DIFF
--- a/src/archive/category/entries.html
+++ b/src/archive/category/entries.html
@@ -56,7 +56,7 @@
     </header>
 
     <!-- ### ヘッダー下 自由挿入エリア ### -->
-    <div class="customize-area　below-header-customize-area">
+    <div class="below-header-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
@@ -70,7 +70,7 @@
                     <div class="main-content__inner">
 
                         <!-- ### トップページ・記事リスト ### -->
-                        <div class="entry-list">
+                        <div class="entry-list top-entry-list">
                             <h2 class="entry-list__title">カテゴリー「{{ Category Name }}」に投稿された記事</h2>
                             <div class="entry-list__description">
                                 <span class="entry-list__hit-count">該当件数：{{ Hit Count }}件</span>
@@ -88,24 +88,14 @@
                                         <h2 class="entry-item__title">
                                             <a href="{{ Entry URL }}" class="entry-item__title-link">{{ Entry Title }}</a>
                                         </h2>
-                                        <div class="entry-item__categories">
-                                            <span class="entry-item__category-item">
-                                                <a href="{{ Category 1 URL }}" class="entry-item__category-item-link">{{ Entry Category-1 Name }}</a>
-                                            </span>
-                                            <span class="entry-item__category-item">
-                                                <a href="{{ Category 2 URL }}" class="entry-item__category-item-link">{{ Entry Category-2 Name }}</a>
-                                            </span>
-                                            <span class="entry-item__category-item">
-                                                <a href="{{ Category 3 URL }}" class="entry-item__category-item-link">{{ Entry Category-3 Name }}</a>
-                                            </span>
-                                        </div>
+                                        <div class="entry-item__description">{{ Entry Desciption }}</div>
                                     </div>
                                 </div>
 
                             </div>
 
                             <!-- ### 表示するデータがない場合 ### -->
-                            <div class="entry-list__no-content">まだ記事が投稿されていません</div>
+                            <div class="entry-list__no-content">まだ記事がありません</div>
                         </div>
 
                         <!-- ページャ -->
@@ -117,7 +107,7 @@
                                     <a href="{{ Previous Page Link}}" class="content-list-pager__previous-link">前のページへ</a>
                                 </span>
                                 <span class="content-list-pager__next">
-                                    <a href="{{ Next Page Link }}" class="content-list-pager__next-link">前のページへ</a>
+                                    <a href="{{ Next Page Link }}" class="content-list-pager__next-link">次のページへ</a>
                                 </span>
 
                                 <!-- ページ分割がない場合 -->
@@ -125,7 +115,7 @@
                                     <a class="content-list-pager__previous-link content-list-pager__previous-link--disabled">前のページへ</a>
                                 </span>
                                 <span class="content-list-pager__next">
-                                    <a class="content-list-pager__next-link content-list-pager__next-link--disabled">前のページへ</a>
+                                    <a class="content-list-pager__next-link content-list-pager__next-link--disabled">次のページへ</a>
                                 </span>
 
                             </div>
@@ -237,19 +227,19 @@
     </div>
 
     <!-- ### フッター上 自由挿入エリア ### -->
-    <div class="customize-area　above-footer-customize-area">
+    <div class="above-footer-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
     <!-- ### フッター ### -->
     <footer class="main-footer">
         <div class="main-footer__inner">
-            <span class="main-footer__blog-title">
+            <div class="main-footer__blog-title">
                     <a href="/" class="main-footer__blog-title-link">{{ Blog Title }}</a>
-            </span>
-            <span class="main-footer__blog-copyright">©2018-2019 <a
-                href="/" target="_blank" class="main-footer__blog-copyright-user-link">@{{ User Screen Name }}</a>, Powered by <a
-                href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
+            </div>
+            <div class="main-footer__blog-copyright">©2018-2019 <a
+                href="/" target="_blank" class="main-footer__blog-copyright-link">@{{ User Screen Name }}</a>, Powered by <a
+                href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-link">Qrunch</a>.</div>
         </div>
     </footer>
     </div>

--- a/src/archive/category/logs.html
+++ b/src/archive/category/logs.html
@@ -56,7 +56,7 @@
     </header>
 
     <!-- ### ヘッダー下 自由挿入エリア ### -->
-    <div class="customize-area　below-header-customize-area">
+    <div class="below-header-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
@@ -70,14 +70,14 @@
                     <div class="main-content__inner">
 
                         <!-- ### トップページ・ログリスト ### -->
-                        <div class="log-list">
+                        <div class="log-list top-log-list">
                             <h2 class="log-list__title">カテゴリー「{{ Category Name }}」に記録されたログ</h2>
                             <div class="log-list__description">
                                 <span class="log-list__hit-count">該当件数：{{ Hit Count }}件</span>
                                 <span class="log-list__type-switch"><a href="{{ Category Entry URL }}" title="このカテゴリーに投稿された記事をみる" class="log-list__type-switch-link">このカテゴリーに投稿された記事をみる</a></span>
                             </div>
 
-                            <div class="log-list__logs">
+                            <div class="log-list__entries">
 
                                 <!-- ### ログ ### -->
                                 <div class="log-item log-item--small">
@@ -88,24 +88,14 @@
                                         <h2 class="log-item__title">
                                             <a href="{{ Log URL }}" class="log-item__title-link">{{ Log Title }}</a>
                                         </h2>
-                                        <div class="log-item__categories">
-                                            <span class="log-item__category-item">
-                                                <a href="{{ Category 1 URL }}" class="log-item__category-item-link">{{ Log Category-1 Name }}</a>
-                                            </span>
-                                            <span class="log-item__category-item">
-                                                <a href="{{ Category 2 URL }}" class="log-item__category-item-link">{{ Log Category-2 Name }}</a>
-                                            </span>
-                                            <span class="log-item__category-item">
-                                                <a href="{{ Category 3 URL }}" class="log-item__category-item-link">{{ Log Category-3 Name }}</a>
-                                            </span>
-                                        </div>
+                                        <div class="log-item__description">{{ Entry Desciption }}</div>
                                     </div>
                                 </div>
 
                             </div>
 
                             <!-- ### 表示するデータがない場合 ### -->
-                            <div class="log-list__no-content">まだログが記録されていません</div>
+                            <div class="log-list__no-content">まだログがありません</div>
                         </div>
 
                         <!-- ページャ -->
@@ -117,7 +107,7 @@
                                     <a href="{{ Previous Page Link}}" class="content-list-pager__previous-link">前のページへ</a>
                                 </span>
                                 <span class="content-list-pager__next">
-                                    <a href="{{ Next Page Link }}" class="content-list-pager__next-link">前のページへ</a>
+                                    <a href="{{ Next Page Link }}" class="content-list-pager__next-link">次のページへ</a>
                                 </span>
 
                                 <!-- ページ分割がない場合 -->
@@ -125,7 +115,7 @@
                                     <a class="content-list-pager__previous-link content-list-pager__previous-link--disabled">前のページへ</a>
                                 </span>
                                 <span class="content-list-pager__next">
-                                    <a class="content-list-pager__next-link content-list-pager__next-link--disabled">前のページへ</a>
+                                    <a class="content-list-pager__next-link content-list-pager__next-link--disabled">次のページへ</a>
                                 </span>
 
                             </div>
@@ -237,19 +227,19 @@
     </div>
 
     <!-- ### フッター上 自由挿入エリア ### -->
-    <div class="customize-area　above-footer-customize-area">
+    <div class="above-footer-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
     <!-- ### フッター ### -->
     <footer class="main-footer">
         <div class="main-footer__inner">
-            <span class="main-footer__blog-title">
+            <div class="main-footer__blog-title">
                     <a href="/" class="main-footer__blog-title-link">{{ Blog Title }}</a>
-            </span>
-            <span class="main-footer__blog-copyright">©2018-2019 <a
-                href="/" target="_blank" class="main-footer__blog-copyright-user-link">@{{ User Screen Name }}</a>, Powered by <a
-                href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
+            </div>
+            <div class="main-footer__blog-copyright">©2018-2019 <a
+                href="/" target="_blank" class="main-footer__blog-copyright-link">@{{ User Screen Name }}</a>, Powered by <a
+                href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-link">Qrunch</a>.</div>
         </div>
     </footer>
     </div>

--- a/src/archive/date/entries.html
+++ b/src/archive/date/entries.html
@@ -56,7 +56,7 @@
     </header>
 
     <!-- ### ヘッダー下 自由挿入エリア ### -->
-    <div class="customize-area　below-header-customize-area">
+    <div class="below-header-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
@@ -70,7 +70,7 @@
                     <div class="main-content__inner">
 
                         <!-- ### トップページ・記事リスト ### -->
-                        <div class="entry-list">
+                        <div class="entry-list top-entry-list">
                             <h2 class="entry-list__title">「{{ Date }}」 に投稿された記事</h2>
                             <div class="entry-list__description">
                                 <span class="entry-list__hit-count">該当件数：{{ Hit Count }}件</span>
@@ -88,24 +88,14 @@
                                         <h2 class="entry-item__title">
                                             <a href="{{ Entry URL }}" class="entry-item__title-link">{{ Entry Title }}</a>
                                         </h2>
-                                        <div class="entry-item__categories">
-                                            <span class="entry-item__category-item">
-                                                <a href="{{ Category 1 URL }}" class="entry-item__category-item-link">{{ Entry Category-1 Name }}</a>
-                                            </span>
-                                            <span class="entry-item__category-item">
-                                                <a href="{{ Category 2 URL }}" class="entry-item__category-item-link">{{ Entry Category-2 Name }}</a>
-                                            </span>
-                                            <span class="entry-item__category-item">
-                                                <a href="{{ Category 3 URL }}" class="entry-item__category-item-link">{{ Entry Category-3 Name }}</a>
-                                            </span>
-                                        </div>
+                                        <div class="entry-item__description">{{ Entry Desciption }}</div>
                                     </div>
                                 </div>
 
                             </div>
 
                             <!-- ### 表示するデータがない場合 ### -->
-                            <div class="entry-list__no-content">まだ記事が投稿されていません</div>
+                            <div class="entry-list__no-content">まだ記事がありません</div>
                         </div>
 
                         <!-- ページャ -->
@@ -117,7 +107,7 @@
                                     <a href="{{ Previous Page Link}}" class="content-list-pager__previous-link">前のページへ</a>
                                 </span>
                                 <span class="content-list-pager__next">
-                                    <a href="{{ Next Page Link }}" class="content-list-pager__next-link">前のページへ</a>
+                                    <a href="{{ Next Page Link }}" class="content-list-pager__next-link">次のページへ</a>
                                 </span>
 
                                 <!-- ページ分割がない場合 -->
@@ -125,7 +115,7 @@
                                     <a class="content-list-pager__previous-link content-list-pager__previous-link--disabled">前のページへ</a>
                                 </span>
                                 <span class="content-list-pager__next">
-                                    <a class="content-list-pager__next-link content-list-pager__next-link--disabled">前のページへ</a>
+                                    <a class="content-list-pager__next-link content-list-pager__next-link--disabled">次のページへ</a>
                                 </span>
 
                             </div>
@@ -237,19 +227,19 @@
     </div>
 
     <!-- ### フッター上 自由挿入エリア ### -->
-    <div class="customize-area　above-footer-customize-area">
+    <div class="above-footer-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
     <!-- ### フッター ### -->
     <footer class="main-footer">
         <div class="main-footer__inner">
-            <span class="main-footer__blog-title">
+            <div class="main-footer__blog-title">
                     <a href="/" class="main-footer__blog-title-link">{{ Blog Title }}</a>
-            </span>
-            <span class="main-footer__blog-copyright">©2018-2019 <a
-                href="/" target="_blank" class="main-footer__blog-copyright-user-link">@{{ User Screen Name }}</a>, Powered by <a
-                href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
+            </div>
+            <div class="main-footer__blog-copyright">©2018-2019 <a
+                href="/" target="_blank" class="main-footer__blog-copyright-link">@{{ User Screen Name }}</a>, Powered by <a
+                href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-link">Qrunch</a>.</div>
         </div>
     </footer>
     </div>

--- a/src/archive/date/logs.html
+++ b/src/archive/date/logs.html
@@ -56,7 +56,7 @@
     </header>
 
     <!-- ### ヘッダー下 自由挿入エリア ### -->
-    <div class="customize-area　below-header-customize-area">
+    <div class="below-header-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
@@ -70,14 +70,14 @@
                     <div class="main-content__inner">
 
                         <!-- ### トップページ・ログリスト ### -->
-                        <div class="log-list">
+                        <div class="log-list top-log-list">
                             <h2 class="log-list__title">「{{ Date }}」に記録されたログ</h2>
                             <div class="log-list__description">
                                 <span class="log-list__hit-count">該当件数：{{ Hit Count }}件</span>
                                 <span class="log-list__type-switch"><a href="{{ Archive Entry URL }}" title="この期間に投稿された記事をみる" class="log-list__type-switch-link">この期間に投稿された記事をみる</a></span>
                             </div>
 
-                            <div class="log-list__logs">
+                            <div class="log-list__entries">
 
                                 <!-- ### ログ ### -->
                                 <div class="log-item log-item--small">
@@ -88,24 +88,14 @@
                                         <h2 class="log-item__title">
                                             <a href="{{ Log URL }}" class="log-item__title-link">{{ Log Title }}</a>
                                         </h2>
-                                        <div class="log-item__categories">
-                                            <span class="log-item__category-item">
-                                                <a href="{{ Category 1 URL }}" class="log-item__category-item-link">{{ Log Category-1 Name }}</a>
-                                            </span>
-                                            <span class="log-item__category-item">
-                                                <a href="{{ Category 2 URL }}" class="log-item__category-item-link">{{ Log Category-2 Name }}</a>
-                                            </span>
-                                            <span class="log-item__category-item">
-                                                <a href="{{ Category 3 URL }}" class="log-item__category-item-link">{{ Log Category-3 Name }}</a>
-                                            </span>
-                                        </div>
+                                        <div class="log-item__description">{{ Entry Desciption }}</div>
                                     </div>
                                 </div>
 
                             </div>
 
                             <!-- ### 表示するデータがない場合 ### -->
-                            <div class="log-list__no-content">まだログが記録されていません</div>
+                            <div class="log-list__no-content">まだログがありません</div>
                         </div>
 
                         <!-- ページャ -->
@@ -117,7 +107,7 @@
                                     <a href="{{ Previous Page Link}}" class="content-list-pager__previous-link">前のページへ</a>
                                 </span>
                                 <span class="content-list-pager__next">
-                                    <a href="{{ Next Page Link }}" class="content-list-pager__next-link">前のページへ</a>
+                                    <a href="{{ Next Page Link }}" class="content-list-pager__next-link">次のページへ</a>
                                 </span>
 
                                 <!-- ページ分割がない場合 -->
@@ -125,7 +115,7 @@
                                     <a class="content-list-pager__previous-link content-list-pager__previous-link--disabled">前のページへ</a>
                                 </span>
                                 <span class="content-list-pager__next">
-                                    <a class="content-list-pager__next-link content-list-pager__next-link--disabled">前のページへ</a>
+                                    <a class="content-list-pager__next-link content-list-pager__next-link--disabled">次のページへ</a>
                                 </span>
 
                             </div>
@@ -237,19 +227,19 @@
     </div>
 
     <!-- ### フッター上 自由挿入エリア ### -->
-    <div class="customize-area　above-footer-customize-area">
+    <div class="above-footer-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
     <!-- ### フッター ### -->
     <footer class="main-footer">
         <div class="main-footer__inner">
-            <span class="main-footer__blog-title">
+            <div class="main-footer__blog-title">
                     <a href="/" class="main-footer__blog-title-link">{{ Blog Title }}</a>
-            </span>
-            <span class="main-footer__blog-copyright">©2018-2019 <a
-                href="/" target="_blank" class="main-footer__blog-copyright-user-link">@{{ User Screen Name }}</a>, Powered by <a
-                href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
+            </div>
+            <div class="main-footer__blog-copyright">©2018-2019 <a
+                href="/" target="_blank" class="main-footer__blog-copyright-link">@{{ User Screen Name }}</a>, Powered by <a
+                href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-link">Qrunch</a>.</div>
         </div>
     </footer>
     </div>

--- a/src/archive/tag/entries.html
+++ b/src/archive/tag/entries.html
@@ -56,7 +56,7 @@
     </header>
     
     <!-- ### ヘッダー下 自由挿入エリア ### -->
-    <div class="customize-area　below-header-customize-area">
+    <div class="below-header-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
@@ -70,7 +70,7 @@
                     <div class="main-content__inner">
 
                         <!-- ### トップページ・記事リスト ### -->
-                        <div class="entry-list">
+                        <div class="entry-list top-entry-list">
                             <h2 class="entry-list__title">タグ「{{ Tag Name }}」がついた記事</h2>
                             <div class="entry-list__description">
                                 <span class="entry-list__hit-count">該当件数：{{ Hit Count }}件</span>
@@ -88,24 +88,14 @@
                                         <h2 class="entry-item__title">
                                             <a href="{{ Entry URL }}" class="entry-item__title-link">{{ Entry Title }}</a>
                                         </h2>
-                                        <div class="entry-item__categories">
-                                            <span class="entry-item__category-item">
-                                                <a href="{{ Category 1 URL }}" class="entry-item__category-item-link">{{ Entry Category-1 Name }}</a>
-                                            </span>
-                                            <span class="entry-item__category-item">
-                                                <a href="{{ Category 2 URL }}" class="entry-item__category-item-link">{{ Entry Category-2 Name }}</a>
-                                            </span>
-                                            <span class="entry-item__category-item">
-                                                <a href="{{ Category 3 URL }}" class="entry-item__category-item-link">{{ Entry Category-3 Name }}</a>
-                                            </span>
-                                        </div>
+                                        <div class="entry-item__description">{{ Entry Desciption }}</div>
                                     </div>
                                 </div>
 
                             </div>
 
                             <!-- ### 表示するデータがない場合 ### -->
-                            <div class="entry-list__no-content">まだ記事が投稿されていません</div>
+                            <div class="entry-list__no-content">まだ記事がありません</div>
                         </div>
 
                         <!-- ページャ -->
@@ -117,7 +107,7 @@
                                     <a href="{{ Previous Page Link}}" class="content-list-pager__previous-link">前のページへ</a>
                                 </span>
                                 <span class="content-list-pager__next">
-                                    <a href="{{ Next Page Link }}" class="content-list-pager__next-link">前のページへ</a>
+                                    <a href="{{ Next Page Link }}" class="content-list-pager__next-link">次のページへ</a>
                                 </span>
 
                                 <!-- ページ分割がない場合 -->
@@ -125,7 +115,7 @@
                                     <a class="content-list-pager__previous-link content-list-pager__previous-link--disabled">前のページへ</a>
                                 </span>
                                 <span class="content-list-pager__next">
-                                    <a class="content-list-pager__next-link content-list-pager__next-link--disabled">前のページへ</a>
+                                    <a class="content-list-pager__next-link content-list-pager__next-link--disabled">次のページへ</a>
                                 </span>
 
                             </div>
@@ -237,19 +227,19 @@
     </div>
 
     <!-- ### フッター上 自由挿入エリア ### -->
-    <div class="customize-area　above-footer-customize-area">
+    <div class="above-footer-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
     <!-- ### フッター ### -->
     <footer class="main-footer">
         <div class="main-footer__inner">
-            <span class="main-footer__blog-title">
+            <div class="main-footer__blog-title">
                     <a href="/" class="main-footer__blog-title-link">{{ Blog Title }}</a>
-            </span>
-            <span class="main-footer__blog-copyright">©2018-2019 <a
-                href="/" target="_blank" class="main-footer__blog-copyright-user-link">@{{ User Screen Name }}</a>, Powered by <a
-                href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
+            </div>
+            <div class="main-footer__blog-copyright">©2018-2019 <a
+                href="/" target="_blank" class="main-footer__blog-copyright-link">@{{ User Screen Name }}</a>, Powered by <a
+                href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-link">Qrunch</a>.</div>
         </div>
     </footer>
     </div>

--- a/src/archive/tag/logs.html
+++ b/src/archive/tag/logs.html
@@ -56,7 +56,7 @@
     </header>
 
     <!-- ### ヘッダー下 自由挿入エリア ### -->
-    <div class="customize-area　below-header-customize-area">
+    <div class="below-header-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
@@ -70,14 +70,14 @@
                     <div class="main-content__inner">
 
                         <!-- ### トップページ・ログリスト ### -->
-                        <div class="log-list">
+                        <div class="log-list top-log-list">
                             <h2 class="log-list__title">タグ「{{ Tag Name }}」がついたログ</h2>
                             <div class="log-list__description">
                                 <span class="log-list__hit-count">該当件数：{{ Hit Count }}件</span>
                                 <span class="log-list__type-switch"><a href="{{ Tag Entry URL }}" title="このタグがついた記事をみる" class="log-list__type-switch-link">このタグがついた記事をみる</a></span>
                             </div>
 
-                            <div class="log-list__logs">
+                            <div class="log-list__entries">
 
                                 <!-- ### ログ ### -->
                                 <div class="log-item log-item--small">
@@ -88,24 +88,14 @@
                                         <h2 class="log-item__title">
                                             <a href="{{ Log URL }}" class="log-item__title-link">{{ Log Title }}</a>
                                         </h2>
-                                        <div class="log-item__categories">
-                                            <span class="log-item__category-item">
-                                                <a href="{{ Category 1 URL }}" class="log-item__category-item-link">{{ Log Category-1 Name }}</a>
-                                            </span>
-                                            <span class="log-item__category-item">
-                                                <a href="{{ Category 2 URL }}" class="log-item__category-item-link">{{ Log Category-2 Name }}</a>
-                                            </span>
-                                            <span class="log-item__category-item">
-                                                <a href="{{ Category 3 URL }}" class="log-item__category-item-link">{{ Log Category-3 Name }}</a>
-                                            </span>
-                                        </div>
+                                        <div class="log-item__description">{{ Entry Desciption }}</div>
                                     </div>
                                 </div>
 
                             </div>
 
                             <!-- ### 表示するデータがない場合 ### -->
-                            <div class="log-list__no-content">まだログが記録されていません</div>
+                            <div class="log-list__no-content">まだログがありません</div>
                         </div>
 
                         <!-- ページャ -->
@@ -117,7 +107,7 @@
                                     <a href="{{ Previous Page Link}}" class="content-list-pager__previous-link">前のページへ</a>
                                 </span>
                                 <span class="content-list-pager__next">
-                                    <a href="{{ Next Page Link }}" class="content-list-pager__next-link">前のページへ</a>
+                                    <a href="{{ Next Page Link }}" class="content-list-pager__next-link">次のページへ</a>
                                 </span>
 
                                 <!-- ページ分割がない場合 -->
@@ -125,7 +115,7 @@
                                     <a class="content-list-pager__previous-link content-list-pager__previous-link--disabled">前のページへ</a>
                                 </span>
                                 <span class="content-list-pager__next">
-                                    <a class="content-list-pager__next-link content-list-pager__next-link--disabled">前のページへ</a>
+                                    <a class="content-list-pager__next-link content-list-pager__next-link--disabled">次のページへ</a>
                                 </span>
 
                             </div>
@@ -237,19 +227,19 @@
     </div>
 
     <!-- ### フッター上 自由挿入エリア ### -->
-    <div class="customize-area　above-footer-customize-area">
+    <div class="above-footer-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
     <!-- ### フッター ### -->
     <footer class="main-footer">
         <div class="main-footer__inner">
-            <span class="main-footer__blog-title">
+            <div class="main-footer__blog-title">
                     <a href="/" class="main-footer__blog-title-link">{{ Blog Title }}</a>
-            </span>
-            <span class="main-footer__blog-copyright">©2018-2019 <a
-                href="/" target="_blank" class="main-footer__blog-copyright-user-link">@{{ User Screen Name }}</a>, Powered by <a
-                href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
+            </div>
+            <div class="main-footer__blog-copyright">©2018-2019 <a
+                href="/" target="_blank" class="main-footer__blog-copyright-link">@{{ User Screen Name }}</a>, Powered by <a
+                href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-link">Qrunch</a>.</div>
         </div>
     </footer>
     </div>

--- a/src/commons.html
+++ b/src/commons.html
@@ -57,7 +57,7 @@
     </header>
 
     <!-- ### ヘッダー下 自由挿入エリア ### -->
-    <div class="customize-area　below-header-customize-area">
+    <div class="below-header-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
@@ -87,20 +87,20 @@
     </div>
 
     <!-- ### フッター上 自由挿入エリア ### -->
-    <div class="customize-area　above-footer-customize-area">
+    <div class="above-footer-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
     <!-- ### フッター ### -->
     <footer class="main-footer">
         <div class="main-footer__inner">
-            <span class="main-footer__blog-title">
+            <div class="main-footer__blog-title">
                 <a href="/" class="main-footer__blog-title-link">{{ Blog Title }}</a>
-            </span>
-            <span class="main-footer__blog-copyright">©2018-2019 <a href="{{ User Page URL }}" target="_blank"
-                    class="main-footer__blog-copyright-user-link">@{{ User Screen Name }}</a>, Powered by <a
+            </div>
+            <div class="main-footer__blog-copyright">©2018-2019 <a href="{{ User Page URL }}" target="_blank"
+                    class="main-footer__blog-copyright-link">@{{ User Screen Name }}</a>, Powered by <a
                     href="https://qrunch.net" target="_blank"
-                    class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
+                    class="main-footer__blog-copyright-link">Qrunch</a>.</div>
         </div>
     </footer>
     </div>

--- a/src/entries/entry.html
+++ b/src/entries/entry.html
@@ -56,7 +56,7 @@
     </header>
 
     <!-- ### ヘッダー下 自由挿入エリア ### -->
-    <div class="customize-area　below-header-customize-area">
+    <div class="below-header-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
@@ -100,13 +100,11 @@
                                 </div>
 
                                 <!-- ### 記事 本文 ### -->
-                                <div class="entry__content">
-                                    <div class="entry-content">
+                                <div class="entry__content content">
                                         {{ Entry Content }}
-                                    </div>
                                 </div>
 
-                                <!-- ### 記事・ログ上（本文下） 自由挿入エリア ### -->
+                                <!-- ### 記事・ログ下（本文下） 自由挿入エリア ### -->
                                 <div class="customize-area below-content-customize-area">
                                     {{ Customize Code }}
                                 </div>
@@ -286,19 +284,19 @@
     </div>
 
     <!-- ### フッター上 自由挿入エリア ### -->
-    <div class="customize-area　above-footer-customize-area">
+    <div class="above-footer-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
     <!-- ### フッター ### -->
     <footer class="main-footer">
         <div class="main-footer__inner">
-            <span class="main-footer__blog-title">
+            <div class="main-footer__blog-title">
                     <a href="/" class="main-footer__blog-title-link">{{ Blog Title }}</a>
-            </span>
-            <span class="main-footer__blog-copyright">©2018-2019 <a
-                href="/" target="_blank" class="main-footer__blog-copyright-user-link">@{{ User Screen Name }}</a>, Powered by <a
-                href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
+            </div>
+            <div class="main-footer__blog-copyright">©2018-2019 <a
+                href="/" target="_blank" class="main-footer__blog-copyright-link">@{{ User Screen Name }}</a>, Powered by <a
+                href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-link">Qrunch</a>.</div>
         </div>
     </footer>
     </div>

--- a/src/entries/index.html
+++ b/src/entries/index.html
@@ -56,7 +56,7 @@
     </header>
 
     <!-- ### ヘッダー下 自由挿入エリア ### -->
-    <div class="customize-area　below-header-customize-area">
+    <div class="below-header-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
@@ -70,7 +70,7 @@
                     <div class="main-content__inner">
 
                         <!-- ### トップページ・記事リスト ### -->
-                        <div class="entry-list">
+                        <div class="entry-list top-entry-list">
                             <h2 class="entry-list__title">記事一覧</h2>
                             <div class="entry-list__entries">
 
@@ -83,24 +83,14 @@
                                         <h2 class="entry-item__title">
                                             <a href="{{ Entry URL }}" class="entry-item__title-link">{{ Entry Title }}</a>
                                         </h2>
-                                        <div class="entry-item__categories">
-                                            <span class="entry-item__category-item">
-                                                <a href="{{ Category 1 URL }}" class="entry-item__category-item-link">{{ Entry Category-1 Name }}</a>
-                                            </span>
-                                            <span class="entry-item__category-item">
-                                                <a href="{{ Category 2 URL }}" class="entry-item__category-item-link">{{ Entry Category-2 Name }}</a>
-                                            </span>
-                                            <span class="entry-item__category-item">
-                                                <a href="{{ Category 3 URL }}" class="entry-item__category-item-link">{{ Entry Category-3 Name }}</a>
-                                            </span>
-                                        </div>
+                                        <div class="entry-item__description">{{ Entry Desciption }}</div>
                                     </div>
                                 </div>
 
                             </div>
 
                             <!-- ### 表示するデータがない場合 ### -->
-                            <div class="entry-list__no-content">まだ記事が投稿されていません</div>
+                            <div class="entry-list__no-content">まだ記事がありません</div>
                         </div>
 
                         <!-- ページャ -->
@@ -112,7 +102,7 @@
                                     <a href="{{ Previous Page Link}}" class="content-list-pager__previous-link">前のページへ</a>
                                 </span>
                                 <span class="content-list-pager__next">
-                                    <a href="{{ Next Page Link }}" class="content-list-pager__next-link">前のページへ</a>
+                                    <a href="{{ Next Page Link }}" class="content-list-pager__next-link">次のページへ</a>
                                 </span>
 
                                 <!-- ページ分割がない場合 -->
@@ -120,7 +110,7 @@
                                     <a class="content-list-pager__previous-link content-list-pager__previous-link--disabled">前のページへ</a>
                                 </span>
                                 <span class="content-list-pager__next">
-                                    <a class="content-list-pager__next-link content-list-pager__next-link--disabled">前のページへ</a>
+                                    <a class="content-list-pager__next-link content-list-pager__next-link--disabled">次のページへ</a>
                                 </span>
 
                             </div>
@@ -232,7 +222,7 @@
     </div>
 
     <!-- ### フッター上 自由挿入エリア ### -->
-    <div class="customize-area　above-footer-customize-area">
+    <div class="above-footer-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
@@ -243,8 +233,8 @@
                     <a href="/" class="main-footer__blog-title-link">{{ Blog Title }}</a>
             </span>
             <span class="main-footer__blog-copyright">©2018-2019 <a
-                href="/" target="_blank" class="main-footer__blog-copyright-user-link">@{{ User Screen Name }}</a>, Powered by <a
-                href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
+                href="/" target="_blank" class="main-footer__blog-copyright-link">@{{ User Screen Name }}</a>, Powered by <a
+                href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-link">Qrunch</a>.</span>
         </div>
     </footer>
     </div>

--- a/src/index.html
+++ b/src/index.html
@@ -56,7 +56,7 @@
     </header>
 
     <!-- ### ヘッダー下 自由挿入エリア ### -->
-    <div class="customize-area　below-header-customize-area">
+    <div class="below-header-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
@@ -70,7 +70,7 @@
                     <div class="main-content__inner">
 
                         <!-- ### トップページ・記事リスト ### -->
-                        <div class="entry-list">
+                        <div class="entry-list top-entry-list">
                             <div class="entry-list__entries">
 
                                 <!-- ### 記事 ### -->
@@ -112,7 +112,7 @@
                                     <a href="{{ Previous Page Link}}" class="content-list-pager__previous-link">前のページへ</a>
                                 </span>
                                 <span class="content-list-pager__next">
-                                    <a href="{{ Next Page Link }}" class="content-list-pager__next-link">前のページへ</a>
+                                    <a href="{{ Next Page Link }}" class="content-list-pager__next-link">次のページへ</a>
                                 </span>
 
                                 <!-- ページ分割がない場合 -->
@@ -120,7 +120,7 @@
                                     <a class="content-list-pager__previous-link content-list-pager__previous-link--disabled">前のページへ</a>
                                 </span>
                                 <span class="content-list-pager__next">
-                                    <a class="content-list-pager__next-link content-list-pager__next-link--disabled">前のページへ</a>
+                                    <a class="content-list-pager__next-link content-list-pager__next-link--disabled">次のページへ</a>
                                 </span>
 
                             </div>
@@ -232,19 +232,19 @@
     </div>
 
     <!-- ### フッター上 自由挿入エリア ### -->
-    <div class="customize-area　above-footer-customize-area">
+    <div class="above-footer-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
     <!-- ### フッター ### -->
     <footer class="main-footer">
         <div class="main-footer__inner">
-            <span class="main-footer__blog-title">
+            <div class="main-footer__blog-title">
                     <a href="/" class="main-footer__blog-title-link">{{ Blog Title }}</a>
-            </span>
-            <span class="main-footer__blog-copyright">©2018-2019 <a
-                href="{{ User Page URL }}" target="_blank" class="main-footer__blog-copyright-user-link">@{{ User Screen Name }}</a>, Powered by <a
-                href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
+            </div>
+            <div class="main-footer__blog-copyright">©2018-2019 <a
+                href="{{ User Page URL }}" target="_blank" class="main-footer__blog-copyright-link">@{{ User Screen Name }}</a>, Powered by <a
+                href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-link">Qrunch</a>.</div>
         </div>
     </footer>
     </div>

--- a/src/logs/index.html
+++ b/src/logs/index.html
@@ -56,7 +56,7 @@
     </header>
 
     <!-- ### ヘッダー下 自由挿入エリア ### -->
-    <div class="customize-area　below-header-customize-area">
+    <div class="below-header-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
@@ -70,9 +70,9 @@
                     <div class="main-content__inner">
 
                         <!-- ### トップページ・ログリスト ### -->
-                        <div class="log-list">
+                        <div class="log-list top-log-list">
                             <h2 class="log-list__title">ログ一覧</h2>
-                            <div class="log-list__logs">
+                            <div class="log-list__entries">
 
                                 <!-- ### ログ ### -->
                                 <div class="log-item log-item--small">
@@ -83,24 +83,14 @@
                                         <h2 class="log-item__title">
                                             <a href="{{ Log URL }}" class="log-item__title-link">{{ Log Title }}</a>
                                         </h2>
-                                        <div class="log-item__categories">
-                                            <span class="log-item__category-item">
-                                                <a href="{{ Category 1 URL }}" class="log-item__category-item-link">{{ Log Category-1 Name }}</a>
-                                            </span>
-                                            <span class="log-item__category-item">
-                                                <a href="{{ Category 2 URL }}" class="log-item__category-item-link">{{ Log Category-2 Name }}</a>
-                                            </span>
-                                            <span class="log-item__category-item">
-                                                <a href="{{ Category 3 URL }}" class="log-item__category-item-link">{{ Log Category-3 Name }}</a>
-                                            </span>
-                                        </div>
+                                        <div class="log-item__description">{{ Entry Desciption }}</div>
                                     </div>
                                 </div>
 
                             </div>
 
                             <!-- ### 表示するデータがない場合 ### -->
-                            <div class="log-list__no-content">まだログが記録されていません</div>
+                            <div class="log-list__no-content">まだログがありません</div>
                         </div>
 
                         <!-- ページャ -->
@@ -232,7 +222,7 @@
     </div>
 
     <!-- ### フッター上 自由挿入エリア ### -->
-    <div class="customize-area　above-footer-customize-area">
+    <div class="above-footer-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
@@ -243,8 +233,8 @@
                     <a href="/" class="main-footer__blog-title-link">{{ Blog Title }}</a>
             </span>
             <span class="main-footer__blog-copyright">©2018-2019 <a
-                href="/" target="_blank" class="main-footer__blog-copyright-user-link">@{{ User Screen Name }}</a>, Powered by <a
-                href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
+                href="/" target="_blank" class="main-footer__blog-copyright-link">@{{ User Screen Name }}</a>, Powered by <a
+                href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-link">Qrunch</a>.</span>
         </div>
     </footer>
     </div>

--- a/src/logs/log.html
+++ b/src/logs/log.html
@@ -56,7 +56,7 @@
     </header>
 
     <!-- ### ヘッダー下 自由挿入エリア ### -->
-    <div class="customize-area　below-header-customize-area">
+    <div class="below-header-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
@@ -100,13 +100,11 @@
                                 </div>
 
                                 <!-- ### ログ 本文 ### -->
-                                <div class="log__content">
-                                    <div class="log-content">
+                                <div class="log__content content">
                                         {{ Log Content }}
-                                    </div>
                                 </div>
 
-                                <!-- ### ログ・ログ上（本文下） 自由挿入エリア ### -->
+                                <!-- ### ログ・ログ下（本文下） 自由挿入エリア ### -->
                                 <div class="customize-area below-content-customize-area">
                                     {{ Customize Code }}
                                 </div>
@@ -286,19 +284,19 @@
     </div>
 
     <!-- ### フッター上 自由挿入エリア ### -->
-    <div class="customize-area　above-footer-customize-area">
+    <div class="above-footer-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
     <!-- ### フッター ### -->
     <footer class="main-footer">
         <div class="main-footer__inner">
-            <span class="main-footer__blog-title">
+            <div class="main-footer__blog-title">
                     <a href="/" class="main-footer__blog-title-link">{{ Blog Title }}</a>
-            </span>
-            <span class="main-footer__blog-copyright">©2018-2019 <a
-                href="/" target="_blank" class="main-footer__blog-copyright-user-link">@{{ User Screen Name }}</a>, Powered by <a
-                href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
+            </div>
+            <div class="main-footer__blog-copyright">©2018-2019 <a
+                href="/" target="_blank" class="main-footer__blog-copyright-link">@{{ User Screen Name }}</a>, Powered by <a
+                href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-link">Qrunch</a>.</div>
         </div>
     </footer>
     </div>

--- a/src/search/entries.html
+++ b/src/search/entries.html
@@ -56,7 +56,7 @@
     </header>
 
     <!-- ### ヘッダー下 自由挿入エリア ### -->
-    <div class="customize-area　below-header-customize-area">
+    <div class="below-header-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
@@ -70,7 +70,7 @@
                     <div class="main-content__inner">
 
                         <!-- ### トップページ・記事リスト ### -->
-                        <div class="entry-list">
+                        <div class="entry-list top-entry-list">
                             <h2 class="entry-list__title">「{{ Word }}」 の検索結果（記事）</h2>
                             <div class="entry-list__description">
                                 <span class="entry-list__hit-count">検索ヒット数：{{ Search Hit Count }}件</span>
@@ -88,24 +88,14 @@
                                         <h2 class="entry-item__title">
                                             <a href="{{ Entry URL }}" class="entry-item__title-link">{{ Entry Title }}</a>
                                         </h2>
-                                        <div class="entry-item__categories">
-                                            <span class="entry-item__category-item">
-                                                <a href="{{ Category 1 URL }}" class="entry-item__category-item-link">{{ Entry Category-1 Name }}</a>
-                                            </span>
-                                            <span class="entry-item__category-item">
-                                                <a href="{{ Category 2 URL }}" class="entry-item__category-item-link">{{ Entry Category-2 Name }}</a>
-                                            </span>
-                                            <span class="entry-item__category-item">
-                                                <a href="{{ Category 3 URL }}" class="entry-item__category-item-link">{{ Entry Category-3 Name }}</a>
-                                            </span>
-                                        </div>
+                                        <div class="entry-item__description">{{ Entry Desciption }}</div>
                                     </div>
                                 </div>
 
                             </div>
 
                             <!-- ### 表示するデータがない場合 ### -->
-                            <div class="entry-list__no-content">まだ記事が投稿されていません</div>
+                            <div class="entry-list__no-content">まだ記事がありません</div>
                         </div>
 
                         <!-- ページャ -->
@@ -117,7 +107,7 @@
                                     <a href="{{ Previous Page Link}}" class="content-list-pager__previous-link">前のページへ</a>
                                 </span>
                                 <span class="content-list-pager__next">
-                                    <a href="{{ Next Page Link }}" class="content-list-pager__next-link">前のページへ</a>
+                                    <a href="{{ Next Page Link }}" class="content-list-pager__next-link">次のページへ</a>
                                 </span>
 
                                 <!-- ページ分割がない場合 -->
@@ -125,7 +115,7 @@
                                     <a class="content-list-pager__previous-link content-list-pager__previous-link--disabled">前のページへ</a>
                                 </span>
                                 <span class="content-list-pager__next">
-                                    <a class="content-list-pager__next-link content-list-pager__next-link--disabled">前のページへ</a>
+                                    <a class="content-list-pager__next-link content-list-pager__next-link--disabled">次のページへ</a>
                                 </span>
 
                             </div>
@@ -237,19 +227,19 @@
     </div>
 
     <!-- ### フッター上 自由挿入エリア ### -->
-    <div class="customize-area　above-footer-customize-area">
+    <div class="above-footer-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
     <!-- ### フッター ### -->
     <footer class="main-footer">
         <div class="main-footer__inner">
-            <span class="main-footer__blog-title">
+            <div class="main-footer__blog-title">
                     <a href="/" class="main-footer__blog-title-link">{{ Blog Title }}</a>
-            </span>
-            <span class="main-footer__blog-copyright">©2018-2019 <a
-                href="/" target="_blank" class="main-footer__blog-copyright-user-link">@{{ User Screen Name }}</a>, Powered by <a
-                href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
+            </div>
+            <div class="main-footer__blog-copyright">©2018-2019 <a
+                href="/" target="_blank" class="main-footer__blog-copyright-link">@{{ User Screen Name }}</a>, Powered by <a
+                href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-link">Qrunch</a>.</div>
         </div>
     </footer>
     </div>

--- a/src/search/logs.html
+++ b/src/search/logs.html
@@ -56,7 +56,7 @@
     </header>
 
     <!-- ### ヘッダー下 自由挿入エリア ### -->
-    <div class="customize-area　below-header-customize-area">
+    <div class="below-header-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
@@ -70,14 +70,14 @@
                     <div class="main-content__inner">
 
                         <!-- ### トップページ・ログリスト ### -->
-                        <div class="log-list">
+                        <div class="log-list top-log-list">
                             <h2 class="log-list__title">「{{ Word }}」 の検索結果（ログ）</h2>
                             <div class="log-list__description">
                                 <span class="log-list__hit-count">検索ヒット数：{{ Search Hit Count }}件</span>
                                 <span class="log-list__type-switch"><a href="{{ Search Entry URL }}" title="このワードで記事を検索する" class="log-list__type-switch-link">このワードで記事を検索する</a></span>
                             </div>
 
-                            <div class="log-list__logs">
+                            <div class="log-list__entries">
 
                                 <!-- ### ログ ### -->
                                 <div class="log-item log-item--small">
@@ -88,24 +88,14 @@
                                         <h2 class="log-item__title">
                                             <a href="{{ Log URL }}" class="log-item__title-link">{{ Log Title }}</a>
                                         </h2>
-                                        <div class="log-item__categories">
-                                            <span class="log-item__category-item">
-                                                <a href="{{ Category 1 URL }}" class="log-item__category-item-link">{{ Log Category-1 Name }}</a>
-                                            </span>
-                                            <span class="log-item__category-item">
-                                                <a href="{{ Category 2 URL }}" class="log-item__category-item-link">{{ Log Category-2 Name }}</a>
-                                            </span>
-                                            <span class="log-item__category-item">
-                                                <a href="{{ Category 3 URL }}" class="log-item__category-item-link">{{ Log Category-3 Name }}</a>
-                                            </span>
-                                        </div>
+                                        <div class="log-item__description">{{ Entry Desciption }}</div>
                                     </div>
                                 </div>
 
                             </div>
 
                             <!-- ### 表示するデータがない場合 ### -->
-                            <div class="log-list__no-content">まだログが記録されていません</div>
+                            <div class="log-list__no-content">まだログがありません</div>
                         </div>
 
                         <!-- ページャ -->
@@ -117,7 +107,7 @@
                                     <a href="{{ Previous Page Link}}" class="content-list-pager__previous-link">前のページへ</a>
                                 </span>
                                 <span class="content-list-pager__next">
-                                    <a href="{{ Next Page Link }}" class="content-list-pager__next-link">前のページへ</a>
+                                    <a href="{{ Next Page Link }}" class="content-list-pager__next-link">次のページへ</a>
                                 </span>
 
                                 <!-- ページ分割がない場合 -->
@@ -125,7 +115,7 @@
                                     <a class="content-list-pager__previous-link content-list-pager__previous-link--disabled">前のページへ</a>
                                 </span>
                                 <span class="content-list-pager__next">
-                                    <a class="content-list-pager__next-link content-list-pager__next-link--disabled">前のページへ</a>
+                                    <a class="content-list-pager__next-link content-list-pager__next-link--disabled">次のページへ</a>
                                 </span>
 
                             </div>
@@ -237,19 +227,19 @@
     </div>
 
     <!-- ### フッター上 自由挿入エリア ### -->
-    <div class="customize-area　above-footer-customize-area">
+    <div class="above-footer-customize-area customize-area">
         {{ Customize Code }}
     </div>
 
     <!-- ### フッター ### -->
     <footer class="main-footer">
         <div class="main-footer__inner">
-            <span class="main-footer__blog-title">
+            <div class="main-footer__blog-title">
                     <a href="/" class="main-footer__blog-title-link">{{ Blog Title }}</a>
-            </span>
-            <span class="main-footer__blog-copyright">©2018-2019 <a
-                href="/" target="_blank" class="main-footer__blog-copyright-user-link">@{{ User Screen Name }}</a>, Powered by <a
-                href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-qrunch-link">Qrunch</a>.</span>
+            </div>
+            <div class="main-footer__blog-copyright">©2018-2019 <a
+                href="/" target="_blank" class="main-footer__blog-copyright-link">@{{ User Screen Name }}</a>, Powered by <a
+                href="https://qrunch.net" target="_blank" class="main-footer__blog-copyright-link">Qrunch</a>.</div>
         </div>
     </footer>
     </div>


### PR DESCRIPTION
全ページを実際のブログと比較し、下記のような修正を行いました。

- 全角スペースを削除
- 記事リストのクラス名修正
- 記事・ログ本文の構造修正
- ページャーのtypo修正
- フッターの構造とクラス名を修正

同じような修正を行っているグループごとにコミットを分けましたので、それぞれの修正箇所はコミットメッセージをご確認いただけますと幸いです。
